### PR TITLE
chat completion support

### DIFF
--- a/src/langchain_replicate/__init__.py
+++ b/src/langchain_replicate/__init__.py
@@ -1,9 +1,11 @@
 # SPDX-License-Identifier: MIT
 
+from langchain_replicate.chat_models import ChatReplicate
 from langchain_replicate.embeddings import ReplicateEmbeddings
 from langchain_replicate.llms import Replicate
 
 __all__ = [
+    "ChatReplicate",
     "Replicate",
     "ReplicateEmbeddings",
 ]

--- a/src/langchain_replicate/chat_models.py
+++ b/src/langchain_replicate/chat_models.py
@@ -1,0 +1,968 @@
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import logging
+from collections.abc import AsyncIterator, Callable, Iterator, Mapping, Sequence
+from operator import itemgetter
+from typing import Any, Literal, cast
+
+from langchain_core.callbacks import (
+    AsyncCallbackManagerForLLMRun,
+    CallbackManagerForLLMRun,
+)
+from langchain_core.language_models import LanguageModelInput
+from langchain_core.language_models.chat_models import (
+    BaseChatModel,
+    agenerate_from_stream,
+    generate_from_stream,
+)
+from langchain_core.messages import (
+    AIMessage,
+    AIMessageChunk,
+    BaseMessage,
+    BaseMessageChunk,
+    ChatMessage,
+    ChatMessageChunk,
+    FunctionMessage,
+    FunctionMessageChunk,
+    HumanMessage,
+    HumanMessageChunk,
+    InvalidToolCall,
+    SystemMessage,
+    SystemMessageChunk,
+    ToolCall,
+    ToolMessage,
+    ToolMessageChunk,
+)
+from langchain_core.messages.ai import UsageMetadata
+from langchain_core.messages.tool import tool_call_chunk
+from langchain_core.output_parsers import JsonOutputParser, PydanticOutputParser
+from langchain_core.output_parsers.openai_tools import (
+    JsonOutputKeyToolsParser,
+    PydanticToolsParser,
+    make_invalid_tool_call,
+    parse_tool_call,
+)
+from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
+from langchain_core.runnables import (
+    Runnable,
+    RunnableMap,
+    RunnablePassthrough,
+)
+from langchain_core.tools import BaseTool
+from langchain_core.utils.function_calling import (
+    convert_to_openai_function,
+    convert_to_openai_tool,
+)
+from langchain_core.utils.pydantic import (
+    TypeBaseModel,
+    is_basemodel_subclass,
+)
+from pydantic import BaseModel, ConfigDict
+from replicate.exceptions import ModelError
+from replicate.prediction import Prediction
+from typing_extensions import override
+
+from langchain_replicate._base import ReplicateBase
+
+logger = logging.getLogger(__name__)
+
+
+def _convert_dict_to_message(_dict: Mapping[str, Any], call_id: str) -> BaseMessage:
+    """Convert a dictionary to a LangChain message.
+
+    Args:
+        _dict: The dictionary.
+        call_id: call id
+
+    Returns:
+        The LangChain message.
+    """
+    role = _dict.get("role")
+    name = _dict.get("name")
+    id_ = call_id
+    if role == "user":
+        return HumanMessage(content=_dict.get("content", ""), id=id_, name=name)
+    if role == "assistant":
+        content = _dict.get("content", "") or ""
+        additional_kwargs: dict = {}
+        if function_call := _dict.get("function_call"):
+            additional_kwargs["function_call"] = dict(function_call)
+        tool_calls = []
+        invalid_tool_calls = []
+        if raw_tool_calls := _dict.get("tool_calls"):
+            additional_kwargs["tool_calls"] = raw_tool_calls
+            for raw_tool_call in raw_tool_calls:
+                try:
+                    tool_calls.append(parse_tool_call(raw_tool_call, return_id=True))
+                except Exception as e:  # pylint: disable=broad-exception-caught
+                    invalid_tool_calls.append(make_invalid_tool_call(raw_tool_call, str(e)))
+        return AIMessage(
+            content=content,
+            additional_kwargs=additional_kwargs,
+            name=name,
+            id=id_,
+            tool_calls=tool_calls,
+            invalid_tool_calls=invalid_tool_calls,
+        )
+    if role == "system":
+        return SystemMessage(content=_dict.get("content", ""), name=name, id=id_)
+    if role == "function":
+        return FunctionMessage(content=_dict.get("content", ""), name=cast(str, _dict.get("name")), id=id_)
+    if role == "tool":
+        additional_kwargs = {}
+        if "name" in _dict:
+            additional_kwargs["name"] = _dict["name"]
+        return ToolMessage(
+            content=_dict.get("content", ""),
+            tool_call_id=cast(str, _dict.get("tool_call_id")),
+            additional_kwargs=additional_kwargs,
+            name=name,
+            id=id_,
+        )
+    return ChatMessage(content=_dict.get("content", ""), role=role, id=id_)  # type: ignore[arg-type]
+
+
+def _format_message_content(content: Any) -> Any:
+    """Format message content."""
+    if content and isinstance(content, list):
+        # Remove unexpected block types
+        formatted_content = []
+        for block in content:
+            if isinstance(block, dict) and "type" in block and block["type"] == "tool_use":
+                continue
+            formatted_content.append(block)
+    else:
+        formatted_content = content
+
+    return formatted_content
+
+
+def _lc_tool_call_to_openai_tool_call(tool_call: ToolCall) -> dict:
+    return {
+        "type": "function",
+        "id": tool_call["id"],
+        "function": {
+            "name": tool_call["name"],
+            "arguments": json.dumps(tool_call["args"]),
+        },
+    }
+
+
+def _lc_invalid_tool_call_to_openai_tool_call(
+    invalid_tool_call: InvalidToolCall,
+) -> dict:
+    return {
+        "type": "function",
+        "id": invalid_tool_call["id"],
+        "function": {
+            "name": invalid_tool_call["name"],
+            "arguments": invalid_tool_call["args"],
+        },
+    }
+
+
+def _base62_encode(num: int) -> str:
+    """Encodes a number in base62 and ensures result is of a specified length."""
+    base62 = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    if num == 0:
+        return base62[0]
+    arr = []
+    base = len(base62)
+    while num:
+        num, rem = divmod(num, base)
+        arr.append(base62[rem])
+    arr.reverse()
+    return "".join(arr)
+
+
+def _convert_tool_call_id_to_mistral_compatible(tool_call_id: str) -> str:
+    """Convert a tool call ID to a Mistral-compatible format"""
+    hash_bytes = hashlib.sha256(tool_call_id.encode()).digest()
+    hash_int = int.from_bytes(hash_bytes, byteorder="big")
+    base62_str = _base62_encode(hash_int)
+    if len(base62_str) >= 9:
+        return base62_str[:9]
+    return base62_str.rjust(9, "0")
+
+
+def _convert_message_to_dict(message: BaseMessage, model_id: str | None) -> dict:
+    """Convert a LangChain message to a dictionary.
+
+    Args:
+        message: The LangChain message.
+        model_id: Type of model to use.
+
+    Returns:
+        The dictionary.
+    """
+    # pylint: disable=too-many-branches
+    message_dict: dict[str, Any] = {"content": _format_message_content(message.content)}
+    if (name := message.name or message.additional_kwargs.get("name")) is not None:
+        message_dict["name"] = name
+
+    # populate role and additional message data
+    if isinstance(message, ChatMessage):
+        message_dict["role"] = message.role
+    elif isinstance(message, HumanMessage):
+        message_dict["role"] = "user"
+    elif isinstance(message, AIMessage):
+        message_dict["role"] = "assistant"
+        if "function_call" in message.additional_kwargs:
+            message_dict["function_call"] = message.additional_kwargs["function_call"]
+        if message.tool_calls or message.invalid_tool_calls:
+            message_dict["tool_calls"] = [_lc_tool_call_to_openai_tool_call(tc) for tc in message.tool_calls] + [
+                _lc_invalid_tool_call_to_openai_tool_call(tc) for tc in message.invalid_tool_calls
+            ]
+        elif "tool_calls" in message.additional_kwargs:
+            message_dict["tool_calls"] = message.additional_kwargs["tool_calls"]
+            tool_call_supported_props = {"id", "type", "function"}
+            message_dict["tool_calls"] = [{k: v for k, v in tool_call.items() if k in tool_call_supported_props} for tool_call in message_dict["tool_calls"]]
+        else:
+            pass
+        # If tool calls present, content null value should be None not empty string.
+        if "function_call" in message_dict or "tool_calls" in message_dict:
+            message_dict["content"] = message_dict["content"] or None
+
+        # Workaround for "mistralai/mistral-large" model when id < 9
+        if model_id and model_id.startswith("mistralai"):
+            tool_calls = message_dict.get("tool_calls", [])
+            if isinstance(tool_calls, list) and tool_calls and isinstance(tool_calls[0], dict):
+                tool_call_id = tool_calls[0].get("id", "")
+                if len(tool_call_id) < 9:
+                    tool_call_id = _convert_tool_call_id_to_mistral_compatible(tool_call_id)
+
+                message_dict["tool_calls"][0]["id"] = tool_call_id
+    elif isinstance(message, SystemMessage):
+        message_dict["role"] = "system"
+    elif isinstance(message, FunctionMessage):
+        message_dict["role"] = "function"
+    elif isinstance(message, ToolMessage):
+        message_dict["role"] = "tool"
+        message_dict["tool_call_id"] = message.tool_call_id
+
+        # Workaround for "mistralai/mistral-large" model when tool_call_id < 9
+        if model_id and model_id.startswith("mistralai"):
+            tool_call_id = message_dict.get("tool_call_id", "")
+            if len(tool_call_id) < 9:
+                tool_call_id = _convert_tool_call_id_to_mistral_compatible(tool_call_id)
+
+            message_dict["tool_call_id"] = tool_call_id
+
+        supported_props = {"content", "role", "tool_call_id"}
+        message_dict = {k: v for k, v in message_dict.items() if k in supported_props}
+    else:
+        raise TypeError(f"Got unknown type {message}")
+    return message_dict
+
+
+def _create_usage_metadata(
+    oai_token_usage: Mapping[str, Any],
+    _prompt_tokens_included: bool,
+) -> UsageMetadata:
+    input_tokens = oai_token_usage.get("prompt_tokens", 0) if not _prompt_tokens_included else 0
+    output_tokens = oai_token_usage.get("completion_tokens", 0)
+    total_tokens = oai_token_usage.get("total_tokens", input_tokens + output_tokens)
+    return UsageMetadata(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=total_tokens,
+    )
+
+
+def _convert_delta_to_message_chunk(
+    delta: Mapping[str, Any],
+    default_class: type[BaseMessageChunk],
+    call_id: str,
+    is_first_tool_chunk: bool,
+) -> BaseMessageChunk:
+    # pylint: disable=too-many-return-statements
+    id_ = call_id
+    role = cast(str, delta.get("role"))
+    content = cast(str, delta.get("content") or "")
+    additional_kwargs: dict = {}
+    if delta.get("function_call"):
+        function_call = dict(delta["function_call"])
+        if "name" in function_call and function_call["name"] is None:
+            function_call["name"] = ""
+        additional_kwargs["function_call"] = function_call
+    tool_call_chunks = []
+    if raw_tool_calls := delta.get("tool_calls"):
+        additional_kwargs["tool_calls"] = raw_tool_calls
+        with contextlib.suppress(KeyError):
+            tool_call_chunks = [
+                tool_call_chunk(
+                    name=rtc["function"].get("name") if is_first_tool_chunk or (rtc.get("id") is not None) else None,
+                    args=rtc["function"].get("arguments"),
+                    # `id` is provided only for the first delta with unique tool_calls
+                    # (multiple tool calls scenario)
+                    id=rtc.get("id"),
+                    index=rtc["index"],
+                )
+                for rtc in raw_tool_calls
+            ]
+
+    if role == "user" or default_class == HumanMessageChunk:
+        return HumanMessageChunk(content=content, id=id_)
+    if role == "assistant" or default_class == AIMessageChunk:
+        return AIMessageChunk(
+            content=content,
+            additional_kwargs=additional_kwargs,
+            id=id_,
+            tool_call_chunks=tool_call_chunks,  # type: ignore[arg-type]
+        )
+    if role == "system" or default_class == SystemMessageChunk:
+        return SystemMessageChunk(content=content, id=id_)
+    if role == "function" or default_class == FunctionMessageChunk:
+        return FunctionMessageChunk(content=content, name=delta["name"], id=id_)
+    if role == "tool" or default_class == ToolMessageChunk:
+        return ToolMessageChunk(content=content, tool_call_id=delta["tool_call_id"], id=id_)
+    if role or default_class == ChatMessageChunk:
+        return ChatMessageChunk(content=content, role=role, id=id_)
+    return default_class(content=content, id=id_)  # type: ignore
+
+
+def _convert_chunk_to_generation_chunk(
+    chunk: Mapping[str, Any],
+    default_chunk_class: type[BaseMessageChunk],
+    is_first_tool_chunk: bool,
+    _prompt_tokens_included: bool,
+) -> ChatGenerationChunk | None:
+    token_usage = chunk.get("usage")
+    choices = chunk.get("choices", [])
+
+    if len(choices) == 0:
+        # logprobs is implicitly None
+        message_chunk = default_chunk_class(content="")  # type: ignore
+        if token_usage and isinstance(message_chunk, AIMessageChunk):
+            message_chunk.usage_metadata = _create_usage_metadata(token_usage, _prompt_tokens_included)
+        generation_chunk = ChatGenerationChunk(message=message_chunk)
+        return generation_chunk
+
+    choice = choices[0]
+    if choice["delta"] is None:
+        return None
+
+    message_chunk = _convert_delta_to_message_chunk(choice["delta"], default_chunk_class, chunk["id"], is_first_tool_chunk)
+    if token_usage and isinstance(message_chunk, AIMessageChunk):
+        message_chunk.usage_metadata = _create_usage_metadata(token_usage, _prompt_tokens_included)
+
+    generation_info = {}
+    if finish_reason := choice.get("finish_reason"):
+        generation_info["finish_reason"] = finish_reason
+        if model_name := chunk.get("model"):
+            generation_info["model_name"] = model_name
+    if logprobs := choice.get("logprobs"):
+        generation_info["logprobs"] = logprobs
+
+    generation_chunk = ChatGenerationChunk(message=message_chunk, generation_info=generation_info or None)
+    return generation_chunk
+
+
+def _is_pydantic_class(obj: Any) -> bool:
+    return isinstance(obj, type) and issubclass(obj, BaseModel)
+
+
+def _convert_to_openai_response_format(
+    schema: dict[str, Any] | type,
+) -> dict | TypeBaseModel:
+    if isinstance(schema, type) and is_basemodel_subclass(schema):
+        return schema
+
+    if isinstance(schema, dict) and "json_schema" in schema and schema.get("type") == "json_schema":
+        return schema
+
+    if isinstance(schema, dict) and "name" in schema and "schema" in schema:
+        return {"type": "json_schema", "json_schema": schema}
+
+    function = convert_to_openai_function(schema)
+    function["schema"] = function.pop("parameters")
+    return {"type": "json_schema", "json_schema": function}
+
+
+class ChatReplicate(ReplicateBase, BaseChatModel):
+    """Replicate chat completion models.
+
+    To use, you should have the ``replicate`` python package installed,
+    and the environment variable ``REPLICATE_API_TOKEN`` set with your API token.
+    You can find your token here: https://replicate.com/account
+
+    The model param is required, but any other model parameters can also
+    be passed in with the format model_kwargs={model_param: value, ...}
+
+    Example:
+        .. code-block:: python
+
+            from langchain_replicate import ChatReplicate
+
+            replicate = ChatReplicate(
+                model=(
+                    "stability-ai/stable-diffusion:"
+                    "27b93a2413e7f36cd83da926f3656280b2931564ff050bf9575f1fdf9bcd7478",
+                ),
+                model_kwargs={"image_dimensions": "512x512"}
+            )
+    """
+
+    streaming: bool = False
+    """Whether to stream the results."""
+
+    model_config = ConfigDict()
+
+    @property
+    def _llm_type(self) -> str:
+        """Return the type of chat model."""
+        return "replicate-chat"
+
+    def _create_message_dicts(
+        self,
+        messages: list[BaseMessage],
+    ) -> list[dict[str, Any]]:
+        message_dicts = [_convert_message_to_dict(m, self.model) for m in messages]
+        return message_dicts
+
+    def _create_chat_result(self, prediction: Prediction, generation_info: dict | None = None) -> ChatResult:
+        if prediction.status == "failed":
+            raise ModelError(prediction)
+
+        if isinstance(prediction.output, list):
+            assert len(prediction.output) == 1, "Expected exactly one output from generation request."
+            output = prediction.output[0]
+        else:
+            output = prediction.output
+        response: Mapping[str, Any]
+        if isinstance(output, str):
+            response = json.loads(output)
+        elif isinstance(output, Mapping):
+            response = output
+        else:
+            logger.error("Unrecognized output shape %s %r", type(output), output)
+            raise ValueError(f"Unrecognized output shape {type(output)} {output!r}")
+
+        token_usage = response.get("usage", {})
+
+        generations = []
+        for choice in response["choices"]:
+            message = _convert_dict_to_message(choice["message"], response["id"])
+
+            if token_usage and isinstance(message, AIMessage):
+                message.usage_metadata = _create_usage_metadata(token_usage, False)
+            generation_info = generation_info or {}
+            generation_info["finish_reason"] = choice.get("finish_reason") if choice.get("finish_reason") is not None else generation_info.get("finish_reason")
+            if "logprobs" in choice:
+                generation_info["logprobs"] = choice["logprobs"]
+            generation = ChatGeneration(message=message, generation_info=generation_info)
+            generations.append(generation)
+        llm_output = {
+            "token_usage": token_usage,
+            "model_name": response.get("model", self.model),
+        }
+
+        return ChatResult(generations=generations, llm_output=llm_output)
+
+    def _create_prediction_input(self, messages: list[BaseMessage], stream: bool, stop: list[str] | None, **kwargs: Any) -> dict[str, Any]:
+        message_dicts = self._create_message_dicts(messages)
+
+        input_: dict[str, Any] = self.model_kwargs | kwargs | {"messages": message_dicts} | self._stop_input(stop) | self._stream_input(stream)
+
+        # Handle the need to convert ChatCompletionNamedToolChoiceParam value to a string
+        tool_choice = input_.get("tool_choice")
+        if tool_choice and isinstance(tool_choice, Mapping):
+            input_["tool_choice"] = json.dumps(tool_choice)
+
+        return input_
+
+    @override
+    def _stream(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> Iterator[ChatGenerationChunk]:
+        input_ = self._create_prediction_input(messages=messages, stream=True, stop=stop, **kwargs)
+        prediction = self._create_prediction(input_)
+
+        default_chunk_class: type[BaseMessageChunk] = AIMessageChunk
+        is_first_tool_chunk = True
+        _prompt_tokens_included = False
+
+        for output in prediction.output_iterator():
+            chunk: Mapping[str, Any]
+            if isinstance(output, str):
+                chunk = json.loads(output)
+            elif isinstance(output, Mapping):
+                chunk = output
+            else:
+                logger.error("Unrecognized output shape %s %r", type(output), output)
+                raise ValueError(f"Unrecognized output shape {type(output)} {output!r}")
+
+            generation_chunk = _convert_chunk_to_generation_chunk(chunk, default_chunk_class, is_first_tool_chunk, _prompt_tokens_included)
+            if generation_chunk is None:
+                continue
+
+            default_chunk_class = type(generation_chunk.message)
+            if (
+                hasattr(generation_chunk.message, "usage_metadata") and generation_chunk.message.usage_metadata  # pyright: ignore[reportAttributeAccessIssue]
+            ):
+                _prompt_tokens_included = True
+            if hasattr(generation_chunk.message, "tool_calls") and isinstance(
+                generation_chunk.message.tool_calls,  # pyright: ignore[reportAttributeAccessIssue]
+                list,
+            ):
+                first_tool_call = (
+                    generation_chunk.message.tool_calls[0]  # pyright: ignore[reportAttributeAccessIssue]
+                    if generation_chunk.message.tool_calls  # pyright: ignore[reportAttributeAccessIssue]
+                    else None
+                )
+                if isinstance(first_tool_call, dict) and first_tool_call.get("name"):
+                    is_first_tool_chunk = False
+
+            yield generation_chunk
+
+    @override
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        if self.streaming:
+            stream_iter = self._stream(messages, stop=stop, run_manager=run_manager, **kwargs)
+            return generate_from_stream(stream_iter)
+
+        input_ = self._create_prediction_input(messages=messages, stream=False, stop=stop, **kwargs)
+        prediction = self._create_prediction(input_)
+
+        prediction.wait()
+
+        return self._create_chat_result(prediction)
+
+    @override
+    async def _astream(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: AsyncCallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[ChatGenerationChunk]:
+        input_ = self._create_prediction_input(messages=messages, stream=True, stop=stop, **kwargs)
+        prediction = await self._async_create_prediction(input_)
+
+        default_chunk_class: type[BaseMessageChunk] = AIMessageChunk
+        is_first_tool_chunk = True
+        _prompt_tokens_included = False
+
+        async for output in prediction.async_output_iterator():
+            chunk: Mapping[str, Any]
+            if isinstance(output, str):
+                chunk = json.loads(output)
+            elif isinstance(output, Mapping):
+                chunk = output
+            else:
+                logger.error("Unrecognized output shape %s %r", type(output), output)
+                raise ValueError(f"Unrecognized output shape {type(output)} {output!r}")
+
+            generation_chunk = _convert_chunk_to_generation_chunk(chunk, default_chunk_class, is_first_tool_chunk, _prompt_tokens_included)
+            if generation_chunk is None:
+                continue
+
+            default_chunk_class = type(generation_chunk.message)
+            if (
+                hasattr(generation_chunk.message, "usage_metadata") and generation_chunk.message.usage_metadata  # pyright: ignore[reportAttributeAccessIssue]
+            ):
+                _prompt_tokens_included = True
+            if hasattr(generation_chunk.message, "tool_calls") and isinstance(
+                generation_chunk.message.tool_calls,  # pyright: ignore[reportAttributeAccessIssue]
+                list,
+            ):
+                first_tool_call = (
+                    generation_chunk.message.tool_calls[0]  # pyright: ignore[reportAttributeAccessIssue]
+                    if generation_chunk.message.tool_calls  # pyright: ignore[reportAttributeAccessIssue]
+                    else None
+                )
+                if isinstance(first_tool_call, dict) and first_tool_call.get("name"):
+                    is_first_tool_chunk = False
+
+            yield generation_chunk
+
+    @override
+    async def _agenerate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: AsyncCallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        if self.streaming:
+            stream_iter = self._astream(messages, stop=stop, run_manager=run_manager, **kwargs)
+            return await agenerate_from_stream(stream_iter)
+
+        input_ = self._create_prediction_input(messages=messages, stream=False, stop=stop, **kwargs)
+        prediction = await self._async_create_prediction(input_)
+
+        await prediction.async_wait()
+
+        return self._create_chat_result(prediction)
+
+    @override
+    def bind_tools(
+        self,
+        tools: Sequence[dict[str, Any] | type | Callable | BaseTool],
+        *,
+        tool_choice: dict | str | Literal["auto", "none", "required", "any"] | bool | None = None,
+        **kwargs: Any,
+    ) -> Runnable[LanguageModelInput, BaseMessage]:
+        """Bind tool-like objects to this chat model.
+
+        Args:
+            tools: A list of tool definitions to bind to this chat model.
+                Can be  a dictionary, pydantic model, callable, or BaseTool. Pydantic
+                models, callables, and BaseTools will be automatically converted to
+                their schema dictionary representation.
+            tool_choice: Which tool to require the model to call.
+                Options are:
+                    - str of the form ``"<<tool_name>>"``: calls <<tool_name>> tool.
+                    - ``"auto"``: automatically selects a tool (including no tool).
+                    - ``"none"``: does not call a tool.
+                    - ``"any"`` or ``"required"`` or ``True``: force at least one tool to be called.
+                    - dict of the form ``{"type": "function", "function": {"name": <<tool_name>>}}``: calls <<tool_name>> tool.
+                    - ``False`` or ``None``: no effect, default OpenAI behavior.
+
+            kwargs: Any additional parameters are passed directly to
+                ``self.bind(**kwargs)``.
+        """  # noqa: E501
+        formatted_tools = [convert_to_openai_tool(tool) for tool in tools]
+        if tool_choice:
+            if isinstance(tool_choice, str):
+                # tool_choice is a tool/function name
+                if tool_choice not in ("auto", "none", "any", "required"):
+                    tool_choice = {
+                        "type": "function",
+                        "function": {"name": tool_choice},
+                    }
+                # We support 'any' since other models use this instead of 'required'.
+                if tool_choice == "any":
+                    tool_choice = "required"
+            elif isinstance(tool_choice, bool):
+                tool_choice = "required"
+            elif isinstance(tool_choice, dict):
+                tool_names = [formatted_tool["function"]["name"] for formatted_tool in formatted_tools]
+                if not any(tool_name == tool_choice["function"]["name"] for tool_name in tool_names):
+                    raise ValueError(f"Tool choice {tool_choice} was specified, but the only provided tools were {tool_names}.")
+            else:
+                raise ValueError(f"Unrecognized tool_choice type. Expected str, bool or dict. Received: {tool_choice}")
+
+            kwargs["tool_choice"] = tool_choice
+        else:
+            kwargs["tool_choice"] = "auto"
+
+        return super().bind(tools=formatted_tools, **kwargs)
+
+    @override
+    def with_structured_output(
+        self,
+        schema: dict | type | None = None,
+        *,
+        method: Literal["function_calling", "json_mode", "json_schema"] = "function_calling",
+        include_raw: bool = False,
+        **kwargs: Any,
+    ) -> Runnable[LanguageModelInput, dict | BaseModel]:
+        """Model wrapper that returns outputs formatted to match the given schema.
+
+        Args:
+            schema: The output schema. Can be passed in as:
+
+                - a JSON Schema,
+                - a TypedDict class,
+                - or a Pydantic class,
+
+                If ``schema`` is a Pydantic class then the model output will be a
+                Pydantic instance of that class, and the model-generated fields will be
+                validated by the Pydantic class. Otherwise the model output will be a
+                dict and will not be validated.
+
+            method: The method for steering model generation, one of:
+
+                - ``'function_calling'``: uses tool-calling features.
+                - ``'json_schema'``: uses dedicated structured output features.
+                - ``'json_mode'``: uses JSON mode.
+
+            include_raw:
+                If False then only the parsed structured output is returned. If
+                an error occurs during model output parsing it will be raised. If True
+                then both the raw model response (a BaseMessage) and the parsed model
+                response will be returned. If an error occurs during output parsing it
+                will be caught and returned as well. The final output is always a dict
+                with keys ``'raw'``, ``'parsed'``, and ``'parsing_error'``.
+
+        Returns:
+            A Runnable that takes same inputs as a :class:`langchain_core.language_models.chat.BaseChatModel`.
+
+            If ``include_raw`` is True, then Runnable outputs a dict with keys:
+
+            - ``'raw'``: BaseMessage
+            - ``'parsed'``: None if there was a parsing error, otherwise the type depends on the ``schema`` as described above.
+            - ``'parsing_error'``: Optional[BaseException]
+
+        .. dropdown:: Example: schema=Pydantic class, method="function_calling", include_raw=False
+
+            .. code-block:: python
+
+                from langchain_replicate import ChatReplicate
+                from pydantic import BaseModel
+
+                class AnswerWithJustification(BaseModel):
+                    '''An answer to the user question along with justification for the answer.'''
+                    answer: str
+                    justification: str
+
+                llm = ChatReplicate(...)
+                structured_llm = llm.with_structured_output(
+                    AnswerWithJustification, , method="function_calling"
+                )
+
+                structured_llm.invoke("What weighs more a pound of bricks or a pound of feathers")
+
+                # -> AnswerWithJustification(
+                #     answer='They weigh the same',
+                #     justification='Both a pound of bricks and a pound of feathers weigh one pound. The weight is the same, but the volume or density of the objects may differ.'
+                # )
+
+        .. dropdown:: Example: schema=Pydantic class, method="function_calling", include_raw=True
+
+            .. code-block:: python
+
+                from langchain_replicate import ChatReplicate
+                from pydantic import BaseModel
+
+                class AnswerWithJustification(BaseModel):
+                    '''An answer to the user question along with justification for the answer.'''
+                    answer: str
+                    justification: str
+
+                llm = ChatReplicate(...)
+                structured_llm = llm.with_structured_output(AnswerWithJustification, include_raw=True)
+
+                structured_llm.invoke("What weighs more a pound of bricks or a pound of feathers")
+                # -> {
+                #     'raw': AIMessage(content='', additional_kwargs={'tool_calls': [{'id': 'call_Ao02pnFYXD6GN1yzc0uXPsvF', 'function': {'arguments': '{"answer":"They weigh the same.","justification":"Both a pound of bricks and a pound of feathers weigh one pound. The weight is the same, but the volume or density of the objects may differ."}', 'name': 'AnswerWithJustification'}, 'type': 'function'}]}),
+                #     'parsed': AnswerWithJustification(answer='They weigh the same.', justification='Both a pound of bricks and a pound of feathers weigh one pound. The weight is the same, but the volume or density of the objects may differ.'),
+                #     'parsing_error': None
+                # }
+
+        .. dropdown:: Example: schema=JSON Schema, method="function_calling", include_raw=False
+
+            .. code-block:: python
+
+                from langchain_replicate import ChatReplicate
+                from pydantic import BaseModel
+                from langchain_core.utils.function_calling import convert_to_openai_tool
+
+                class AnswerWithJustification(BaseModel):
+                    '''An answer to the user question along with justification for the answer.'''
+                    answer: str
+                    justification: str
+
+                dict_schema = convert_to_openai_tool(AnswerWithJustification)
+                llm = ChatReplicate(...)
+                structured_llm = llm.with_structured_output(dict_schema)
+
+                structured_llm.invoke("What weighs more a pound of bricks or a pound of feathers")
+                # -> {
+                #     'answer': 'They weigh the same',
+                #     'justification': 'Both a pound of bricks and a pound of feathers weigh one pound. The weight is the same, but the volume and density of the two substances differ.'
+                # }
+
+        .. dropdown:: Example: schema=Pydantic class, method="json_schema", include_raw=True
+
+            .. code-block::
+
+                from langchain_replicate import ChatReplicate
+                from pydantic import BaseModel
+
+                class AnswerWithJustification(BaseModel):
+                    '''An answer to the user question along with justification for the answer.'''
+
+                    answer: str
+                    justification: str
+
+                llm = ChatReplicate(...)
+                structured_llm = llm.with_structured_output(
+                    AnswerWithJustification,
+                    method="json_schema",
+                    include_raw=True
+                )
+
+                structured_llm.invoke(
+                    "What weighs more a pound of bricks or a pound of feathers"
+                )
+                # -> {
+                #     'raw': AIMessage(content='', additional_kwargs={'tool_calls': [{'id': 'chatcmpl-tool-bfbd6f6dd33b438990c5ddf277485971', 'type': 'function', 'function': {'name': 'AnswerWithJustification', 'arguments': '{"answer": "They weigh the same", "justification": "A pound is a unit of weight or mass, so both a pound of bricks and a pound of feathers weigh the same amount, one pound."}'}}]}, response_metadata={'token_usage': {'completion_tokens': 45, 'prompt_tokens': 275, 'total_tokens': 320}, 'model_name': 'meta-llama/llama-3-3-70b-instruct', 'system_fingerprint': '', 'finish_reason': 'stop'}, id='chatcmpl-461ca5bd-1982-412c-b886-017c483bf481---8c18b06eead65ae4691364798787bda7---71896588-efa5-439f-a25f-d1abfe289f5a', tool_calls=[{'name': 'AnswerWithJustification', 'args': {'answer': 'They weigh the same', 'justification': 'A pound is a unit of weight or mass, so both a pound of bricks and a pound of feathers weigh the same amount, one pound.'}, 'id': 'chatcmpl-tool-bfbd6f6dd33b438990c5ddf277485971', 'type': 'tool_call'}], usage_metadata={'input_tokens': 275, 'output_tokens': 45, 'total_tokens': 320}),
+                #     'parsed': AnswerWithJustification(answer='They weigh the same', justification='A pound is a unit of weight or mass, so both a pound of bricks and a pound of feathers weigh the same amount, one pound.'),
+                #     'parsing_error': None
+                # }
+
+        .. dropdown:: Example: schema=function schema, method="json_schema", include_raw=False
+
+            .. code-block:: python
+
+                from langchain_replicate import ChatReplicate
+                from pydantic import BaseModel
+
+                function__schema = {
+                    'name': 'AnswerWithJustification',
+                    'description': 'An answer to the user question along with justification for the answer.',
+                    'parameters': {
+                        'type': 'object',
+                        'properties': {
+                            'answer': {'type': 'string'},
+                            'justification': {'description': 'A justification for the answer.', 'type': 'string'}
+                        },
+                       'required': ['answer']
+                   }
+               }
+
+                llm = ChatReplicate(...)
+                structured_llm = llm.with_structured_output(
+                    function__schema,
+                    method="json_schema",
+                    include_raw=False
+                )
+
+                structured_llm.invoke(
+                    "What weighs more a pound of bricks or a pound of feathers"
+                )
+                # -> {
+                #     'answer': 'They weigh the same',
+                #     'justification': 'Both a pound of bricks and a pound of feathers weigh one pound. The weight is the same, but the volume and density of the two substances differ.'
+                # }
+
+        .. dropdown:: Example: schema=Pydantic schema, method="json_mode", include_raw=True
+
+            .. code-block::
+
+                from langchain_replicate import ChatReplicate
+                from pydantic import BaseModel
+
+                class AnswerWithJustification(BaseModel):
+                    answer: str
+                    justification: str
+
+                llm = ChatReplicate(...)
+                structured_llm = llm.with_structured_output(
+                    AnswerWithJustification,
+                    method="json_mode",
+                    include_raw=True
+                )
+
+                structured_llm.invoke(
+                    "Answer the following question. "
+                    "Make sure to return a JSON blob with keys 'answer' and 'justification'.\n\n"
+                    "What's heavier a pound of bricks or a pound of feathers?"
+                )
+                # -> {
+                #     'raw': AIMessage(content='{\n    "answer": "They are both the same weight.",\n    "justification": "Both a pound of bricks and a pound of feathers weigh one pound. The difference lies in the volume and density of the materials, not the weight." \n}'),
+                #     'parsed': AnswerWithJustification(answer='They are both the same weight.', justification='Both a pound of bricks and a pound of feathers weigh one pound. The difference lies in the volume and density of the materials, not the weight.'),
+                #     'parsing_error': None
+                # }
+
+        .. dropdown:: Example: schema=None, method="json_mode", include_raw=True
+
+            .. code-block::
+
+                from langchain_replicate import ChatReplicate
+
+                llm = ChatReplicate(...)
+                structured_llm = llm.with_structured_output(method="json_mode", include_raw=True)
+
+                structured_llm.invoke(
+                    "Answer the following question. "
+                    "Make sure to return a JSON blob with keys 'answer' and 'justification'.\n\n"
+                    "What's heavier a pound of bricks or a pound of feathers?"
+                )
+                # -> {
+                #     'raw': AIMessage(content='{\n    "answer": "They are both the same weight.",\n    "justification": "Both a pound of bricks and a pound of feathers weigh one pound. The difference lies in the volume and density of the materials, not the weight." \n}'),
+                #     'parsed': {
+                #         'answer': 'They are both the same weight.',
+                #         'justification': 'Both a pound of bricks and a pound of feathers weigh one pound. The difference lies in the volume and density of the materials, not the weight.'
+                #     },
+                #     'parsing_error': None
+                # }
+        """  # noqa: E501 # pylint: disable=line-too-long
+        if kwargs:
+            raise ValueError(f"Received unsupported arguments {kwargs}")
+        is_pydantic_schema = _is_pydantic_class(schema)
+        if method == "function_calling":
+            if schema is None:
+                raise ValueError("schema must be specified when method is not 'json_mode'. Received None.")
+            formatted_tool = convert_to_openai_tool(schema)
+            tool_name = formatted_tool["function"]["name"]
+            llm = self.bind_tools(
+                [schema],
+                tool_choice=tool_name,
+                ls_structured_output_format={
+                    "kwargs": {"method": method},
+                    "schema": formatted_tool,
+                },
+            )
+            if is_pydantic_schema:
+                output_parser: Runnable = PydanticToolsParser(
+                    tools=[schema],  # type: ignore[list-item]
+                    first_tool_only=True,  # type: ignore[list-item]
+                )
+            else:
+                output_parser = JsonOutputKeyToolsParser(key_name=tool_name, first_tool_only=True)
+        elif method == "json_mode":
+            llm = self.bind(
+                response_format={"type": "json_object"},
+                ls_structured_output_format={
+                    "kwargs": {"method": method},
+                    "schema": schema,
+                },
+            )
+            output_parser = (
+                PydanticOutputParser(pydantic_object=schema)  # type: ignore[arg-type]
+                if is_pydantic_schema
+                else JsonOutputParser()
+            )
+        elif method == "json_schema":
+            if schema is None:
+                raise ValueError("schema must be specified when method is not 'json_mode'. Received None.")
+            response_format = _convert_to_openai_response_format(schema)
+            if is_pydantic_schema:
+                response_format = {
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": schema.__name__,  # type: ignore[union-attr]
+                        "description": schema.__doc__,
+                        "schema": schema.model_json_schema(),  # type: ignore[union-attr]
+                    },
+                }
+            bind_kwargs = {
+                "response_format": response_format,
+                "ls_structured_output_format": {
+                    "kwargs": {"method": method},
+                    "schema": convert_to_openai_tool(schema),
+                },
+            }
+            llm = self.bind(**bind_kwargs)
+            output_parser = (
+                PydanticOutputParser(pydantic_object=schema)  # type: ignore[arg-type]
+                if is_pydantic_schema
+                else JsonOutputParser()
+            )
+        else:
+            raise ValueError(f"Unrecognized method argument. Expected one of 'function_calling', 'json_mode' or 'json_schema'. Received: '{method}'")
+
+        if include_raw:
+            parser_assign = RunnablePassthrough.assign(parsed=itemgetter("raw") | output_parser, parsing_error=lambda _: None)
+            parser_none = RunnablePassthrough.assign(parsed=lambda _: None)
+            parser_with_fallback = parser_assign.with_fallbacks([parser_none], exception_key="parsing_error")
+            return RunnableMap(raw=llm) | parser_with_fallback
+        return llm | output_parser

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 import os
+from typing import Any
 
 import pytest
 from assertpy import assert_that
@@ -13,3 +14,144 @@ def replicate_api_token(monkeypatch) -> str:
     assert_that(api_token).is_not_none().is_not_empty()
     monkeypatch.delenv("REPLICATE_API_TOKEN")
     return api_token  # type: ignore
+
+
+@pytest.fixture
+def documents() -> list[dict[str, Any]]:
+    # pylint: disable=line-too-long
+    doc_list: list[dict[str, Any]] = [
+        {
+            "text": """Tonight. I call on the Senate to: Pass the Freedom to Vote Act. Pass the John Lewis Voting Rights Act. And while you're at it, pass the Disclose Act so Americans can know who is funding our elections.
+Tonight, I'd like to honor someone who has dedicated his life to serve this country: Justice Stephen Breyer—an Army veteran, Constitutional scholar, and retiring Justice of the United States Supreme Court. Justice Breyer, thank you for your service.
+One of the most serious constitutional responsibilities a President has is nominating someone to serve on the United States Supreme Court.
+And I did that 4 days ago, when I nominated Circuit Court of Appeals Judge Ketanji Brown Jackson. One of our nation's top legal minds, who will continue Justice Breyer's legacy of excellence.
+A former top litigator in private practice. A former federal public defender. And from a family of public school educators and police officers. A consensus builder. Since she's been nominated, she's received a broad range of support—from the Fraternal Order of Police to former judges appointed by Democrats and Republicans.
+And if we are to advance liberty and justice, we need to secure the Border and fix the immigration system.
+We can do both. At our border, we've installed new technology like cutting-edge scanners to better detect drug smuggling.
+We've set up joint patrols with Mexico and Guatemala to catch more human traffickers.
+We're putting in place dedicated immigration judges so families fleeing persecution and violence can have their cases heard faster.
+We're securing commitments and supporting partners in South and Central America to host more refugees and secure their own borders.
+We can do all this while keeping lit the torch of liberty that has led generations of immigrants to this land—my forefathers and so many of yours.
+Provide a pathway to citizenship for Dreamers, those on temporary status, farm workers, and essential workers.
+Revise our laws so businesses have the workers they need and families don't wait decades to reunite.
+It's not only the right thing to do—it's the economically smart thing to do.
+That's why immigration reform is supported by everyone from labor unions to religious leaders to the U.S. Chamber of Commerce.""",  # noqa: E501
+            "doc_id": "15",
+        },
+        {
+            "text": """That's why I've proposed closing loopholes so the very wealthy don't pay a lower tax rate than a teacher or a firefighter.
+So that's my plan. It will grow the economy and lower costs for families.
+So what are we waiting for? Let's get this done. And while you're at it, confirm my nominees to the Federal Reserve, which plays a critical role in fighting inflation.
+My plan will not only lower costs to give families a fair shot, it will lower the deficit.
+The previous Administration not only ballooned the deficit with tax cuts for the very wealthy and corporations, it undermined the watchdogs whose job was to keep pandemic relief funds from being wasted.
+But in my administration, the watchdogs have been welcomed back.
+We're going after the criminals who stole billions in relief money meant for small businesses and millions of Americans.
+And tonight, I'm announcing that the Justice Department will name a chief prosecutor for pandemic fraud.
+By the end of this year, the deficit will be down to less than half what it was before I took office.
+The only president ever to cut the deficit by more than one trillion dollars in a single year.
+Lowering your costs also means demanding more competition.
+I'm a capitalist, but capitalism without competition isn't capitalism.
+It's exploitation—and it drives up prices.
+When corporations don't have to compete, their profits go up, your prices go up, and small businesses and family farmers and ranchers go under.
+We see it happening with ocean carriers moving goods in and out of America.
+During the pandemic, these foreign-owned companies raised prices by as much as 1,000% and made record profits.
+Tonight, I'm announcing a crackdown on these companies overcharging American businesses and consumers.
+And as Wall Street firms take over more nursing homes, quality in those homes has gone down and costs have gone up.
+That ends on my watch.
+Medicare is going to set higher standards for nursing homes and make sure your loved ones get the care they deserve and expect.""",  # noqa: E501
+            "doc_id": "10",
+        },
+        {
+            "text": """Madam Speaker, Madam Vice President, our First Lady and Second Gentleman. Members of Congress and the Cabinet. Justices of the Supreme Court. My fellow Americans.
+Last year COVID-19 kept us apart. This year we are finally together again.
+Tonight, we meet as Democrats Republicans and Independents. But most importantly as Americans.
+With a duty to one another to the American people to the Constitution.
+And with an unwavering resolve that freedom will always triumph over tyranny.
+Six days ago, Russia's Vladimir Putin sought to shake the foundations of the free world thinking he could make it bend to his menacing ways. But he badly miscalculated.
+He thought he could roll into Ukraine and the world would roll over. Instead he met a wall of strength he never imagined.
+He met the Ukrainian people.
+From President Zelenskyy to every Ukrainian, their fearlessness, their courage, their determination, inspires the world.
+Groups of citizens blocking tanks with their bodies. Everyone from students to retirees teachers turned soldiers defending their homeland.
+In this struggle as President Zelenskyy said in his speech to the European Parliament “Light will win over darkness.” The Ukrainian Ambassador to the United States is here tonight.
+Let each of us here tonight in this Chamber send an unmistakable signal to Ukraine and to the world.
+Please rise if you are able and show that, Yes, we the United States of America stand with the Ukrainian people.
+Throughout our history we've learned this lesson when dictators do not pay a price for their aggression they cause more chaos.
+They keep moving.
+And the costs and the threats to America and the world keep rising.
+That's why the NATO Alliance was created to secure peace and stability in Europe after World War 2.
+The United States is a member along with 29 other nations.
+It matters. American diplomacy matters. American resolve matters.
+Putin's latest attack on Ukraine was premeditated and unprovoked.
+He rejected repeated efforts at diplomacy.
+He thought the West and NATO wouldn't respond. And he thought he could divide us at home. Putin was wrong. We were ready.  Here is what we did.
+We prepared extensively and carefully.""",  # noqa: E501
+            "doc_id": "1",
+        },
+        {
+            "text": """It's time for Americans to get back to work and fill our great downtowns again.  People working from home can feel safe to begin to return to the office.
+We're doing that here in the federal government. The vast majority of federal workers will once again work in person.
+Our schools are open. Let's keep it that way. Our kids need to be in school.
+And with 75% of adult Americans fully vaccinated and hospitalizations down by 77%, most Americans can remove their masks, return to work, stay in the classroom, and move forward safely.
+We achieved this because we provided free vaccines, treatments, tests, and masks.
+Of course, continuing this costs money.
+I will soon send Congress a request.
+The vast majority of Americans have used these tools and may want to again, so I expect Congress to pass it quickly.
+Fourth, we will continue vaccinating the world.
+We've sent 475 Million vaccine doses to 112 countries, more than any other nation.
+And we won't stop.
+We have lost so much to COVID-19. Time with one another. And worst of all, so much loss of life.
+Let's use this moment to reset. Let's stop looking at COVID-19 as a partisan dividing line and see it for what it is: A God-awful disease.
+Let's stop seeing each other as enemies, and start seeing each other for who we really are: Fellow Americans.
+We can't change how divided we've been. But we can change how we move forward—on COVID-19 and other issues we must face together.
+I recently visited the New York City Police Department days after the funerals of Officer Wilbert Mora and his partner, Officer Jason Rivera.
+They were responding to a 9-1-1 call when a man shot and killed them with a stolen gun.
+Officer Mora was 27 years old.
+Officer Rivera was 22.
+Both Dominican Americans who'd grown up on the same streets they later chose to patrol as police officers.""",  # noqa: E501
+            "doc_id": 13,
+        },
+    ]
+    return doc_list
+
+
+@pytest.fixture
+def tools() -> list[dict[str, Any]]:
+    tool_list: list[dict[str, Any]] = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_current_weather",
+                "description": "Get the current weather in a given location",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "location": {"description": "The city, e.g. San Francisco, CA", "type": "string"},
+                        "unit": {"enum": ["celsius", "fahrenheit"], "type": "string"},
+                    },
+                    "required": ["location"],
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "get_stock_price",
+                "description": "Retrieves the lowest and highest stock prices for a given ticker and date.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "ticker": {"type": "string", "description": 'The stock ticker symbol, e.g., "IBM".'},
+                        "date": {"type": "string", "description": 'The date in "YYYY-MM-DD" format for which you want to get stock prices.'},
+                    },
+                    "required": ["ticker", "date"],
+                },
+            },
+        },
+    ]
+    return tool_list
+
+
+@pytest.fixture
+def embed_texts() -> list[str]:
+    texts = ["What is Pi?", "Cats are mammals", "Snakes are reptiles"]
+    return texts

--- a/tests/test_chat_models.py
+++ b/tests/test_chat_models.py
@@ -1,0 +1,213 @@
+# SPDX-License-Identifier: MIT
+
+"""Test ChatReplicate API wrapper."""
+
+from typing import Any, cast
+
+import pytest
+from assertpy import assert_that
+from langchain_core.messages import AIMessage, HumanMessage, ToolCall, ToolMessage
+from langchain_core.utils.function_calling import convert_to_openai_tool
+from pydantic import BaseModel
+
+from langchain_replicate import ChatReplicate
+
+TEST_MODEL_LANG = "ibm-granite/granite-3.3-8b-instruct"
+
+
+class AnswerWithJustification(BaseModel):
+    """An answer to the user question along with justification for the answer."""
+
+    answer: str
+    justification: str
+
+
+class TestChat:
+    def test_invoke(self) -> None:
+        """Test invoke."""
+        llm = ChatReplicate(model=TEST_MODEL_LANG)
+        output = llm.invoke("What is Pi?")
+        assert_that(output).is_instance_of(AIMessage)
+        assert_that(output.text()).is_not_none().is_not_empty().contains("Pi")
+
+    @pytest.mark.asyncio
+    async def test_ainvoke(self) -> None:
+        """Test ainvoke."""
+        llm = ChatReplicate(model=TEST_MODEL_LANG)
+        output = await llm.ainvoke("What is Pi?")
+        assert_that(output).is_instance_of(AIMessage)
+        assert_that(output.text()).is_not_none().is_not_empty().contains("Pi")
+
+    def test_with_apikey(self, replicate_api_token: str) -> None:
+        """Test with apikey."""
+        llm = ChatReplicate(model=TEST_MODEL_LANG, replicate_api_token=replicate_api_token)
+        output = llm.invoke("What is Pi?")
+        assert_that(output).is_instance_of(AIMessage)
+        assert_that(output.text()).is_not_none().is_not_empty().contains("Pi")
+
+    def test_invoke_streaming(self) -> None:
+        """Test invoke streaming."""
+        llm = ChatReplicate(model=TEST_MODEL_LANG, streaming=True)
+        output = llm.invoke("What is Pi?")
+        assert_that(output).is_instance_of(AIMessage)
+        assert_that(output.text()).is_not_none().is_not_empty().contains("Pi")
+
+    @pytest.mark.asyncio
+    async def test_ainvoke_streaming(self) -> None:
+        """Test ainvoke streaming."""
+        llm = ChatReplicate(model=TEST_MODEL_LANG, streaming=True)
+        output = await llm.ainvoke("What is Pi?")
+        assert_that(output).is_instance_of(AIMessage)
+        assert_that(output.text()).is_not_none().is_not_empty().contains("Pi")
+
+    def test_model_kwargs(self) -> None:
+        """Test model_kwargs."""
+        llm = ChatReplicate(model=TEST_MODEL_LANG, model_kwargs={"max_tokens": 10, "temperature": 0.01})
+        long_output = llm.invoke("What is Pi?")
+        llm = ChatReplicate(model=TEST_MODEL_LANG, model_kwargs={"max_tokens": 5, "temperature": 0.01})
+        short_output = llm.invoke("What is Pi?")
+        assert_that(len(short_output.text())).is_less_than(len(long_output.text()))
+        assert_that(llm.model_kwargs).contains_only("max_tokens", "temperature").contains_entry({"max_tokens": 5}, {"temperature": 0.01})
+
+    def test_invoke_stop(self) -> None:
+        """Test invoke stop parameter."""
+        llm = ChatReplicate(model=TEST_MODEL_LANG, model_kwargs={"temperature": 0.01})
+        long_output = llm.invoke("What is Pi?")
+        short_output = llm.invoke("What is Pi?", stop=["3.14"])
+        assert_that(long_output.text()).contains("3.14")
+        assert_that(short_output.text()).does_not_contain("3.14")
+
+    def test_stream(self) -> None:
+        """Test stream."""
+        llm = ChatReplicate(model=TEST_MODEL_LANG)
+        stream = llm.stream("What is Pi?")
+        combined = next(stream, None)
+        assert_that(combined).is_not_none()
+        if combined is not None:
+            combined += list(stream)
+            assert_that(combined.text()).is_not_empty().contains("Pi")
+
+    @pytest.mark.asyncio
+    async def test_astream(self) -> None:
+        """Test astream."""
+        llm = ChatReplicate(model=TEST_MODEL_LANG)
+        astream = llm.astream("What is Pi?")
+        combined = await anext(astream, None)
+        assert_that(combined).is_not_none()
+        if combined is not None:
+            combined += [chunk async for chunk in astream]
+            assert_that(combined.text()).is_not_empty().contains("Pi")
+
+    def test_content_array(self) -> None:
+        """Test content array."""
+        llm = ChatReplicate(model=TEST_MODEL_LANG)
+        messages = [HumanMessage(content=[{"type": "text", "text": "What is Pi?"}])]
+        output = llm.invoke(messages)
+        assert_that(output).is_instance_of(AIMessage)
+        assert_that(output.text()).is_not_none().is_not_empty().contains("Pi")
+
+    def test_documents(self, documents: list[dict[str, Any]]) -> None:
+        """Test documents."""
+        llm = ChatReplicate(model=TEST_MODEL_LANG)
+        messages = [HumanMessage(content="What did the president say about Ketanji Brown Jackson?")]
+        output = llm.invoke(messages, documents=documents)
+        assert_that(output).is_instance_of(AIMessage)
+        assert_that(output.text()).is_not_none().is_not_empty().contains("Supreme")
+
+    def test_chat_template_kwargs(self, documents: list[dict[str, Any]]) -> None:
+        """Test chat_template_kwargs."""
+        llm = ChatReplicate(model=TEST_MODEL_LANG)
+        messages = [HumanMessage(content="What did the president say about Ketanji Brown Jackson?")]
+        chat_template_kwargs: dict[str, Any] = {"documents": documents}
+        output = llm.invoke(messages, chat_template_kwargs=chat_template_kwargs)
+        assert_that(output).is_instance_of(AIMessage)
+        assert_that(output.text()).is_not_none().is_not_empty().contains("Supreme")
+
+    def test_tool_call(self, tools: list[dict[str, Any]]) -> None:
+        """Test tools."""
+        llm = ChatReplicate(model=TEST_MODEL_LANG)
+        messages = [HumanMessage(content="What is the weather like in Boston today?")]
+        llm_tools = llm.bind_tools(tools=tools)
+        output = llm_tools.invoke(messages)
+        assert_that(output).is_instance_of(AIMessage)
+        response = cast(AIMessage, output)
+        assert_that(response.tool_calls).is_not_none().is_length(1)
+        assert_that(response.tool_calls[0]["name"]).is_equal_to("get_current_weather")
+
+    def test_tool_choice(self, tools: list[dict[str, Any]]) -> None:
+        """Test tool_choice."""
+        llm = ChatReplicate(model=TEST_MODEL_LANG)
+        messages = [HumanMessage(content="What is the weather like in Boston today?")]
+        llm_tools = llm.bind_tools(tools=tools, tool_choice="get_current_weather")
+        output = llm_tools.invoke(messages)
+        assert_that(output).is_instance_of(AIMessage)
+        response = cast(AIMessage, output)
+        assert_that(response.tool_calls).is_not_none().is_length(1)
+        assert_that(response.tool_calls[0]["name"]).is_equal_to("get_current_weather")
+
+    def test_tool_response(self, tools: list[dict[str, Any]]) -> None:
+        """Test tool response."""
+        llm = ChatReplicate(model=TEST_MODEL_LANG)
+        messages = [
+            HumanMessage(content="What is the weather like in Boston today?"),
+            AIMessage(content="", tool_calls=[ToolCall(id="chatcmpl-tool-92d6ee08f1f14bab9a593271ca4174ab", name="function", args={"location": "Boston, MA", "unit": "celsius"})]),
+            ToolMessage(content="Boston is sunny with a temperature of 30°C.", tool_call_id="chatcmpl-tool-92d6ee08f1f14bab9a593271ca4174ab"),
+        ]
+        output = llm.invoke(messages, tools=tools)
+        assert_that(output).is_instance_of(AIMessage)
+        assert_that(output.text()).is_not_none().is_not_empty().contains("Boston", "30")
+
+    def test_structured_response_pydantic(self) -> None:
+        """Test structured response with Pydantic class."""
+        llm = ChatReplicate(model=TEST_MODEL_LANG)
+        structured_llm = llm.with_structured_output(AnswerWithJustification, method="function_calling")
+        output = structured_llm.invoke("What weighs more a pound of bricks or a pound of feathers")
+        assert_that(output).is_not_none().is_instance_of(AnswerWithJustification)
+        response = cast(AnswerWithJustification, output)
+        assert_that(response.answer).is_not_none().is_not_empty()
+        assert_that(response.justification).is_not_none().is_not_empty()
+
+    def test_structured_response_pydantic_raw(self) -> None:
+        """Test raw structured response with Pydantic class."""
+        llm = ChatReplicate(model=TEST_MODEL_LANG)
+        structured_llm = llm.with_structured_output(AnswerWithJustification, method="function_calling", include_raw=True)
+        output = structured_llm.invoke("What weighs more a pound of bricks or a pound of feathers")
+        assert_that(output).is_not_none().is_instance_of(dict)
+        response = cast(dict[str, Any], output)
+        assert_that(response).contains_key("raw", "parsed", "parsing_error")
+        assert_that(response["raw"]).is_instance_of(AIMessage)
+        assert_that(response["parsed"]).is_instance_of(AnswerWithJustification)
+        assert_that(response["parsing_error"]).is_none()
+
+    def test_structured_response_schema(self) -> None:
+        """Test structured response with schema dict."""
+        llm = ChatReplicate(model=TEST_MODEL_LANG)
+        schema = convert_to_openai_tool(AnswerWithJustification)
+        structured_llm = llm.with_structured_output(schema)
+        output = structured_llm.invoke("What weighs more a pound of bricks or a pound of feathers")
+        assert_that(output).is_not_none().is_instance_of(dict)
+        response = cast(dict[str, Any], output)
+        assert_that(response["answer"]).is_not_none().is_not_empty()
+        assert_that(response["justification"]).is_not_none().is_not_empty()
+
+    def test_structured_response_json_schema(self) -> None:
+        """Test structured response with Pydantic class."""
+        llm = ChatReplicate(model=TEST_MODEL_LANG)
+        structured_llm = llm.with_structured_output(AnswerWithJustification, method="json_schema")
+        output = structured_llm.invoke("What weighs more a pound of bricks or a pound of feathers")
+        assert_that(output).is_not_none().is_instance_of(AnswerWithJustification)
+        response = cast(AnswerWithJustification, output)
+        assert_that(response.answer).is_not_none().is_not_empty()
+        assert_that(response.justification).is_not_none().is_not_empty()
+
+    def test_structured_response_json_mode(self) -> None:
+        """Test structured response with Pydantic class."""
+        llm = ChatReplicate(model=TEST_MODEL_LANG)
+        structured_llm = llm.with_structured_output(method="json_mode", include_raw=True)
+        output = structured_llm.invoke("What weighs more a pound of bricks or a pound of feathers")
+        assert_that(output).is_not_none().is_instance_of(dict)
+        response = cast(dict[str, Any], output)
+        assert_that(response).contains_key("raw", "parsed", "parsing_error")
+        assert_that(response["raw"]).is_instance_of(AIMessage)
+        assert_that(response["parsed"]).is_instance_of(dict)
+        assert_that(response["parsing_error"]).is_none()

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -14,38 +14,55 @@ TEST_MODEL_COLD = "ibm-granite/granite-embedding-278m-multilingual"
 
 
 class TestEmbedding:
-    def test_replicate_embed_query(self) -> None:
+    def test_embed_query(self, embed_texts: list[str]) -> None:
         """Test embedding of single string."""
         llm = ReplicateEmbeddings(model=TEST_MODEL_WARM, texts_value_mapping=json.dumps)
-        output = llm.embed_query("What is LangChain")
+        output = llm.embed_query(embed_texts[0])
         assert_that(output).is_instance_of(list).is_not_empty()
         assert_that(output[0]).is_instance_of(float)
 
-    def test_replicate_embed_query_with_apikey(self, replicate_api_token: str) -> None:
+    @pytest.mark.asyncio
+    async def test_aembed_query(self, embed_texts: list[str]) -> None:
+        """Test async embedding of single string."""
+        llm = ReplicateEmbeddings(model=TEST_MODEL_WARM, texts_value_mapping=json.dumps)
+        output = await llm.aembed_query(embed_texts[0])
+        assert_that(output).is_instance_of(list).is_not_empty()
+        assert_that(output[0]).is_instance_of(float)
+
+    def test_embed_query_with_apikey(self, embed_texts: list[str], replicate_api_token: str) -> None:
         """Test specifying api key."""
         llm = ReplicateEmbeddings(model=TEST_MODEL_WARM, texts_value_mapping=json.dumps, replicate_api_token=replicate_api_token)
-        output = llm.embed_query("What is LangChain")
+        output = llm.embed_query(embed_texts[0])
         assert_that(output).is_instance_of(list).is_not_empty()
         assert_that(output[0]).is_instance_of(float)
 
-    def test_replicate_embed_documents(self) -> None:
+    def test_embed_documents(self, embed_texts: list[str]) -> None:
         """Test embedding of multiple strings."""
         llm = ReplicateEmbeddings(model=TEST_MODEL_WARM, texts_value_mapping=json.dumps)
-        output = llm.embed_documents(["What is LangChain", "Cats are mammals"])
-        assert_that(output).is_instance_of(list).is_not_empty()
+        output = llm.embed_documents(embed_texts)
+        assert_that(output).is_instance_of(list).is_not_empty().is_length(len(embed_texts))
         assert_that(output[0]).is_instance_of(list).is_not_empty()
         assert_that(output[0][0]).is_instance_of(float)
 
-    def test_replicate_embed_model_kwargs(self) -> None:
+    @pytest.mark.asyncio
+    async def test_aembed_documents(self, embed_texts: list[str]) -> None:
+        """Test async embedding of multiple strings."""
+        llm = ReplicateEmbeddings(model=TEST_MODEL_WARM, texts_value_mapping=json.dumps)
+        output = await llm.aembed_documents(embed_texts)
+        assert_that(output).is_instance_of(list).is_not_empty().is_length(len(embed_texts))
+        assert_that(output[0]).is_instance_of(list).is_not_empty()
+        assert_that(output[0][0]).is_instance_of(float)
+
+    def test_embed_model_kwargs(self) -> None:
         """Test model_kwargs."""
         llm = ReplicateEmbeddings(model=TEST_MODEL_WARM, texts_value_mapping=json.dumps, model_kwargs={"batch_size": 16})
         assert_that(llm.model_kwargs).contains_only("batch_size").contains_entry({"batch_size": 16})
 
     @pytest.mark.slow
-    def test_replicate_embed_cold(self) -> None:
+    def test_embed_cold(self, embed_texts: list[str]) -> None:
         """Test embedding of multiple strings on cold model with default list[str] input shape."""
         llm = ReplicateEmbeddings(model=TEST_MODEL_COLD)
-        output = llm.embed_documents(["What is LangChain", "Cats are mammals"])
-        assert_that(output).is_instance_of(list).is_not_empty()
+        output = llm.embed_documents(embed_texts)
+        assert_that(output).is_instance_of(list).is_not_empty().is_length(len(embed_texts))
         assert_that(output[0]).is_instance_of(list).is_not_empty()
         assert_that(output[0][0]).is_instance_of(float)

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -2,6 +2,7 @@
 
 """Test Replicate API wrapper."""
 
+import pytest
 from assertpy import assert_that
 
 from langchain_replicate import Replicate
@@ -13,39 +14,71 @@ TEST_MODEL_LANG = "meta/meta-llama-3-8b-instruct"
 
 
 class TestLLM:
-    def test_replicate_call(self) -> None:
-        """Test simple non-streaming call."""
+    def test_invoke(self) -> None:
+        """Test invoke."""
         llm = Replicate(model=TEST_MODEL_HELLO)
-        output = llm.invoke("What is LangChain")
-        assert_that(output).is_instance_of(str)
+        output = llm.invoke("What is Pi?")
+        assert_that(output).is_not_none().is_not_empty().contains("Pi")
 
-    def test_replicate_call_with_apikey(self, replicate_api_token: str) -> None:
+    @pytest.mark.asyncio
+    async def test_ainvoke(self) -> None:
+        """Test ainvoke."""
+        llm = Replicate(model=TEST_MODEL_HELLO)
+        output = await llm.ainvoke("What is Pi?")
+        assert_that(output).is_not_none().is_not_empty().contains("Pi")
+
+    def test_with_apikey(self, replicate_api_token: str) -> None:
         """Test specifying api key."""
         llm = Replicate(model=TEST_MODEL_HELLO, replicate_api_token=replicate_api_token)
-        output = llm.invoke("What is LangChain")
-        assert_that(output).is_instance_of(str)
+        output = llm.invoke("What is Pi?")
+        assert_that(output).is_not_none().is_not_empty().contains("Pi")
 
-    def test_replicate_streaming_call(self) -> None:
-        """Test streaming call."""
+    def test_invoke_streaming(self) -> None:
+        """Test invoke streaming."""
         callback_handler = FakeCallbackHandler()
         llm = Replicate(streaming=True, callbacks=[callback_handler], model=TEST_MODEL_HELLO)
-        output = llm.invoke("What is LangChain")
-        assert_that(output).is_instance_of(str)
+        output = llm.invoke("What is Pi?")
+        assert_that(output).is_not_none().is_not_empty().contains("Pi")
 
-    def test_replicate_model_kwargs(self) -> None:
-        """Test simple non-streaming call."""
-        llm = Replicate(  # type: ignore[call-arg]
-            model=TEST_MODEL_LANG, model_kwargs={"max_new_tokens": 10, "temperature": 0.01}
-        )
-        long_output = llm.invoke("What is LangChain")
-        llm = Replicate(  # type: ignore[call-arg]
-            model=TEST_MODEL_LANG, model_kwargs={"max_new_tokens": 5, "temperature": 0.01}
-        )
-        short_output = llm.invoke("What is LangChain")
+    @pytest.mark.asyncio
+    async def test_ainvoke_streaming(self) -> None:
+        """Test invoke streaming."""
+        callback_handler = FakeCallbackHandler()
+        llm = Replicate(streaming=True, callbacks=[callback_handler], model=TEST_MODEL_HELLO)
+        output = await llm.ainvoke("What is Pi?")
+        assert_that(output).is_not_none().is_not_empty().contains("Pi")
+
+    def test_model_kwargs(self) -> None:
+        """Test model_kwargs."""
+        llm = Replicate(model=TEST_MODEL_LANG, model_kwargs={"max_tokens": 10, "temperature": 0.01})
+        long_output = llm.invoke("What is Pi?")
+        llm = Replicate(model=TEST_MODEL_LANG, model_kwargs={"max_tokens": 5, "temperature": 0.01})
+        short_output = llm.invoke("What is Pi?")
         assert_that(len(short_output)).is_less_than(len(long_output))
-        assert_that(llm.model_kwargs).contains_only("max_new_tokens", "temperature").contains_entry({"max_new_tokens": 5}, {"temperature": 0.01})
+        assert_that(llm.model_kwargs).contains_only("max_tokens", "temperature").contains_entry({"max_tokens": 5}, {"temperature": 0.01})
 
-    def test_replicate_input(self) -> None:
-        """Test alias input parameter."""
-        llm = Replicate(model=TEST_MODEL_LANG, input={"max_new_tokens": 10})  # type: ignore
-        assert_that(llm.model_kwargs).contains_only("max_new_tokens").contains_entry({"max_new_tokens": 10})
+    def test_alias_input(self) -> None:
+        """Test input model_kwarg alias parameter."""
+        llm = Replicate(model=TEST_MODEL_LANG, input={"max_tokens": 10})  # type: ignore
+        assert_that(llm.model_kwargs).contains_only("max_tokens").contains_entry({"max_tokens": 10})
+
+    def test_stream(self) -> None:
+        """Test stream."""
+        llm = Replicate(model=TEST_MODEL_LANG)
+        stream = llm.stream("What is Pi?")
+        combined = next(stream, None)
+        assert_that(combined).is_not_none()
+        if combined is not None:
+            combined += "".join(stream)
+            assert_that(combined).is_not_empty().contains("Pi")
+
+    @pytest.mark.asyncio
+    async def test_astream(self) -> None:
+        """Test astream."""
+        llm = Replicate(model=TEST_MODEL_LANG)
+        astream = llm.astream("What is Pi?")
+        combined = await anext(astream, None)
+        assert_that(combined).is_not_none()
+        if combined is not None:
+            combined += "".join([chunk async for chunk in astream])
+            assert_that(combined).is_not_empty().contains("Pi")


### PR DESCRIPTION
We add a ChatReplicate class to use chat completion API on a model hosted on Replicate.

This class includes bind_tools and with_structured_output methods. These methods rely upon the model supporting tools, tool_choice, and response_format parameters.

langchain_ibm.ChatWatsonx was a great source of knowledge and code used in this implementation.

