### PR TITLE
Add SPDX license identifiers and update setup-uv action

### DIFF
--- a/.github/actions/python_setup/action.yaml
+++ b/.github/actions/python_setup/action.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 name: 'python_setup'
 description: 'Setup for Python and uv'
 
@@ -5,21 +7,17 @@ inputs:
   python-version:
     description: 'Python version, supporting MAJOR.MINOR only'
     required: true
-    type: string
   uv-version:
     description: 'uv version, default latest'
     required: false
-    type: string
     default: 'latest'
   enable-cache:
     description: 'Enable caching uv cache, default true'
     required: false
-    type: boolean
-    default: true
+    default: 'true'
   save-cache:
     description: 'Save the uv cache, false if pull_request'
     required: false
-    type: boolean
     default: ${{ github.event_name != 'pull_request' }}
 
 runs:
@@ -33,7 +31,7 @@ runs:
 
     - name: 'Setup uv ${{ inputs.uv-version }}'
       id: setup-uv
-      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       with:
         python-version: ${{ steps.setup-python.outputs.python-version }}
         version: ${{ inputs.uv-version }}

--- a/.github/pinact.yaml
+++ b/.github/pinact.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 version: 3
 min_age: # cooldown
   value: 7

--- a/.poutine.yml
+++ b/.poutine.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 ignoreForks: true
 
 skip:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 # Run `pre-commit install` to activate pre-commit hooks


### PR DESCRIPTION
# Summary

This pull request adds SPDX license identifiers to configuration files and updates the `setup-uv` action version. It also removes explicit type declarations from GitHub Actions inputs and adjusts default value formatting for consistency.

# Files Changed

📄 `.github/actions/python_setup/action.yaml`

Adds MIT license SPDX identifier at the top of the file. Updates the `setup-uv` action from v8.1.0 to v8.2.0 (commit hash updated). Removes `type` declarations from all input parameters (`python-version`, `uv-version`, `enable-cache`, `save-cache`) and changes the `enable-cache` default value from boolean `true` to string `'true'` for consistency.

📄 `.github/pinact.yaml`

Adds MIT license SPDX identifier at the top of the pinact configuration file.

📄 `.poutine.yml`

Adds MIT license SPDX identifier at the top of the Poutine configuration file.

📄 `.pre-commit-config.yaml`

Adds MIT license SPDX identifier at the top of the pre-commit configuration file.