### PR TITLE
fix: use Annotated for Field type hints

### DIFF
--- a/src/langchain_replicate/_base.py
+++ b/src/langchain_replicate/_base.py
@@ -76,7 +76,7 @@ class ReplicateBase(BaseModel, abc.ABC):
     """Base model for Replicate integrations"""
 
     model: str
-    model_kwargs: dict[str, Any] = Field(default_factory=dict)
+    model_kwargs: Annotated[dict[str, Any], Field(default_factory=dict)]
     replicate_api_token: Annotated[SecretStr | str | None, BeforeValidator(_validate_api_token), PlainSerializer(_get_secret, when_used="json-unless-none")] = None
     version_obj: Annotated[Any | None, Field(exclude=True), BeforeValidator(_validate_version)] = None
     """Optionally pass in the model version object during initialization to avoid

--- a/src/langchain_replicate/embeddings.py
+++ b/src/langchain_replicate/embeddings.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
-from typing import Any
+from typing import Annotated, Any
 
 from langchain_core.embeddings import Embeddings
 from pydantic import ConfigDict, Field
@@ -34,11 +34,14 @@ class ReplicateEmbeddings(ReplicateBase, Embeddings):
     """
 
     texts_key: str | None = None
-    texts_value_mapping: Callable[[Sequence[str]], Any] | None = Field(
-        default=None,
-        exclude=True,
-        repr=False,
-    )
+    texts_value_mapping: Annotated[
+        Callable[[Sequence[str]], Any] | None,
+        Field(
+            default=None,
+            exclude=True,
+            repr=False,
+        ),
+    ]
     """Can be used to map the input list of strings for the embeddings to some
         type other than List[str]. For example, if the model requires the strings as a JSON
         formatted string, this field can be set to `json.dumps`. If the model requires newline

--- a/src/langchain_replicate/llms.py
+++ b/src/langchain_replicate/llms.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import AsyncIterator, Iterable, Iterator
-from typing import Any
+from typing import Annotated, Any
 
 from langchain_core.callbacks import AsyncCallbackManagerForLLMRun, CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
@@ -43,13 +43,13 @@ class Replicate(ReplicateBase, LLM):
             )
     """
 
-    model_kwargs: dict[str, Any] = Field(default_factory=dict, validation_alias="input")
+    model_kwargs: Annotated[dict[str, Any], Field(default_factory=dict, validation_alias="input")]
     prompt_key: str | None = None
 
     streaming: bool = False
     """Whether to stream the results."""
 
-    stop: list[str] = Field(default_factory=list)
+    stop: Annotated[list[str], Field(default_factory=list)]
     """Stop sequences to early-terminate generation."""
 
     model_config = ConfigDict(


### PR DESCRIPTION
- Wrap Field declarations with Annotated type hints in _base.py, embeddings.py, and llms.py
- Ensures proper type checking with pydantic Field metadata

